### PR TITLE
Support MongoDB query logging

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -12,14 +12,14 @@ services:
     as3_modlr.store:
         class: As3\Modlr\Store\Store
         arguments:
-            - @as3_modlr.metadata.factory
-            - @as3_modlr.storage_manager
-            - @as3_modlr.data_types.factory
-            - @as3_modlr.event_dispatcher
+            - "@as3_modlr.metadata.factory"
+            - "@as3_modlr.storage_manager"
+            - "@as3_modlr.data_types.factory"
+            - "@as3_modlr.event_dispatcher"
 
     as3_modlr.util.entity:
         class: As3\Modlr\Util\EntityUtility
-        arguments: [ @as3_modlr.rest.configuration, @as3_modlr.data_types.factory ]
+        arguments: [ "@as3_modlr.rest.configuration", "@as3_modlr.data_types.factory" ]
 
     as3_modlr.util.validator:
         class: As3\Modlr\Util\Validator


### PR DESCRIPTION
This PR implements support for logging MongoDB queries via the Symfony logger. Also fixes YAML definitions for full Symfony 3+ compatibility.
![screenshot 2016-03-27 16 10 17](https://cloud.githubusercontent.com/assets/1778222/14067901/7bcc4466-f436-11e5-8e1c-9ca7bf32462a.png)
