### PR TITLE
Index Management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/Command/Schema/Create.php
+++ b/Command/Schema/Create.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace As3\Bundle\ModlrBundle\Command\Schema;
+
+use As3\Bundle\ModlrBundle\Schema\Manager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Utilizes the Schema Manager to create or update indices
+ *
+ * @author  Josh Worden <solocommand@gmail.com>
+ */
+class Create extends Command
+{
+    /**
+     * @var Manager
+     */
+    private $manager;
+
+    /**
+     * Constructor.
+     *
+     * @param   Manager     $manager
+     */
+    public function __construct(Manager $manager)
+    {
+        parent::__construct();
+        $this->manager = $manager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('as3:modlr:schema:create')
+            ->setDescription('Creates model indices.')
+            ->addArgument('type', InputArgument::OPTIONAL, 'Specify the model type to create for.')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $type = $input->getArgument('type') ?: null;
+        $types = (null === $type) ? 'all types' : sprintf('model type "%s"', $type);
+
+        $count = count($this->manager->getIndices($type));
+        $output->writeln(sprintf('Creating <info>%s</info> %s for <info>%s</info>',$count, $count == 1 ? 'index' : 'indices', $types));
+
+        foreach ($this->manager->getIndices($type) as $index) {
+            $output->writeln(sprintf('    Creating index <info>%s</info> for model <info>%s</info>', $index['name'], $index['model_type']));
+            $this->manager->createIndex($index);
+        }
+
+        $output->writeln('<info>Done!</info>');
+    }
+}

--- a/DependencyInjection/As3ModlrExtension.php
+++ b/DependencyInjection/As3ModlrExtension.php
@@ -22,6 +22,9 @@ class As3ModlrExtension extends Extension
         // Process the config.
         $config = $this->processConfiguration(new Configuration(), $configs);
 
+        // Index definitions
+        Utility::appendParameter('schema', 'indices', $config['schema_indices'], $container);
+
         // Load bundle services.
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');

--- a/README.md
+++ b/README.md
@@ -84,7 +84,12 @@ You can customize where your definitions are stored by setting the `models_dir` 
 
 See [modlr documentation](#) for additional information.
 
-This bundle provides a command to rebuild modlr's metadatacache:
+This bundle provides commands to rebuild modlr's metadatacache:
 ```
 app/console as3:modlr:metadata:cache:clear [model_type] [--no-warm]
+```
+
+Create collection schema:
+```
+app/console as3:modlr:schema:create [model_type]
 ```

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -17,9 +17,22 @@ services:
             - "@as3_modlr.data_types.factory"
             - "@as3_modlr.event_dispatcher"
 
+    as3_modlr.schema_manager:
+        class: As3\Bundle\ModlrBundle\Schema\Manager
+        public: false
+        arguments:
+            - "@as3_modlr.store"
+            - "%as3_modlr.schema%"
+
     as3_modlr.util.entity:
         class: As3\Modlr\Util\EntityUtility
         arguments: [ "@as3_modlr.rest.configuration", "@as3_modlr.data_types.factory" ]
 
     as3_modlr.util.validator:
         class: As3\Modlr\Util\Validator
+
+    as3_modlr.command.schema:
+        class: As3\Bundle\ModlrBundle\Command\Schema\Create
+        arguments: [ "@as3_modlr.schema_manager" ]
+        tags:
+            - { name: "console.command"}

--- a/Schema/Manager.php
+++ b/Schema/Manager.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace As3\Bundle\ModlrBundle\Schema;
+
+use As3\Modlr\Store\Store;
+// use As3\Modlr\Metadata\Schema\IndexDefinition; // StorageMetadata?
+
+/**
+ * Handles requests to create or update indices
+ *
+ * @author  Josh Worden <solocommand@gmail.com>
+ * @todo    This should be updated to read indices from the metadata factory
+ */
+class Manager
+{
+    /**
+     * @var     array
+     */
+    private $indices = [];
+
+    /**
+     * @var     Store
+     */
+    private $store;
+
+    /**
+     * @param   Store   $store      The As3\Modlr\Store instance
+     * @param   array   $schema     The bundle's schema configuration
+     */
+    public function __construct(Store $store, array $schema = [])
+    {
+        $this->store = $store;
+        $this->indices = isset($schema['indices']) ? $schema['indices'] : [];
+    }
+
+    /**
+     * Returns the loaded indices
+     *
+     * @param   string  $type   The model type to retrieve indices for
+     * @return  array
+     */
+    public function getIndices($type = null)
+    {
+        if (null === $type) {
+            return $this->indices;
+        }
+        $out = [];
+        foreach ($this->indices as $index) {
+            if ($index['model_type'] === $type) {
+                $out[] = $index;
+            }
+        }
+        return $out;
+    }
+
+    /**
+     * Creates an index from the supplied data.
+     * @todo    Change to Metadata\Schema\IndexDefinition or something later
+     *
+     * @param   array       $index  Associative array containin index data
+     *
+     * @return  boolean     If the index was created successfully
+     */
+    public function createIndex(array $index)
+    {
+        $index['options']['background'] = true;
+        $type = $index['model_type'];
+        $metadata = $this->store->getMetadataForType($type);
+        $collection = $this->store->getPersisterFor($type)->getQuery()->getModelCollection($metadata);
+        return $collection->ensureIndex($index['keys'], $index['options']);
+    }
+}


### PR DESCRIPTION
This PR adds support for defining available indices at the bundle level. Also includes a command to create those indices against the underlying collection.

---
- [x] Underlying support for managing indices
- [x] Command for creation of indices

Future updates can include:
- `sync`ing indexes (removing all indices not currently defined, and updating existing)
  - Include generation of unique key name for index based on recursively sorted properties
- Retrieve schema information from underlying metadata definitions

---

![screen shot 2016-09-26 at 4 20 12 pm](https://cloud.githubusercontent.com/assets/1778222/18852293/72b21a68-8405-11e6-8513-1fff4324a7dc.png)
